### PR TITLE
Mark not generating when an error is thrown

### DIFF
--- a/juntagrico_list_gen/views.py
+++ b/juntagrico_list_gen/views.py
@@ -16,9 +16,16 @@ logging.basicConfig(format=format, level=logging.INFO, datefmt="%H:%M:%S")
 
 def list_gen_thread():
     logging.info("Starting list generation: Depot list")
-    call_command("cs_generate_depot_list")
-    logging.info("List generation done")
     lg = m.ListGeneration.objects.select_for_update()
+    try:   
+        call_command("cs_generate_depot_list")
+    except:
+        with transaction.atomic():
+            lg = lg.first()
+            lg.generating = False
+            lg.save()
+        logging.info("Error during list generation")
+    logging.info("List generation done")
     with transaction.atomic():
         lg = lg.first()
         lg.generating = False

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def get_requirements(requirements_file):
 
 setup(
     name='juntagrico-list-gen',
-    version='0.0.8',
+    version='0.0.9',
     packages=find_packages(),
     include_package_data=True,
     license='LPGLv3',


### PR DESCRIPTION
If list generation failed it could not be restarted. Even better would be to also add the error to the db to communicate failure to the user.